### PR TITLE
Fix issue with specific locale causing failure in `src/make.sh`.

### DIFF
--- a/src/apply_word_hits.rb
+++ b/src/apply_word_hits.rb
@@ -18,12 +18,12 @@ dicname = filename
 
 # jawiki_hits を読み込む
 # jawiki_hits	0	0	34	中居正広
-file = File.new("jawiki-latest-all-titles-in-ns0.hits", "r")
+file = File.new("jawiki-latest-all-titles-in-ns0.hits", "r", encoding: "UTF-8")
 	lines = file.read.split("\n")
 file.close
 
 # mozcdic-ut を jawiki_hits に追加
-file = File.new(filename, "r")
+file = File.new(filename, "r", encoding: "UTF-8")
 	lines = lines + file.read.split("\n")
 file.close
 

--- a/src/count_word_hits.rb
+++ b/src/count_word_hits.rb
@@ -12,7 +12,7 @@ require 'zlib'
 filename = "jawiki-latest-all-titles-in-ns0.gz"
 dicname = "jawiki-latest-all-titles-in-ns0.hits"
 
-gz = Zlib::GzipReader.open(filename)
+gz = Zlib::GzipReader.open(filename, encoding: "UTF-8")
 	lines = gz.read.split("\n")
 gz.close
 

--- a/src/remove_duplicate_ut_entries.rb
+++ b/src/remove_duplicate_ut_entries.rb
@@ -21,7 +21,7 @@ id_mozc = id_mozc.split("\n")[-1]
 filename = ARGV[0]
 dicname = filename
 
-file = File.new(filename, "r")
+file = File.new(filename, "r", encoding: "UTF-8")
 	lines = file.read.split("\n")
 file.close
 
@@ -38,7 +38,7 @@ end
 
 lines = lines.sort
 
-dicfile = File.new(dicname, "w")
+dicfile = File.new(dicname, "w", encoding: "UTF-8")
 
 lines.length.times do |i|
 	s1 = lines[i].split("	")


### PR DESCRIPTION
### Issue
If `Encoding.default_external` in ruby is `US-ASCII`, `src/make.sh` fails with the following stderr.
```
Cloning into 'mozcdic-ut-jawiki'...
Cloning into 'mozcdic-ut-personal-names'...
Cloning into 'mozcdic-ut-place-names'...
Cloning into 'mozcdic-ut-sudachidict'...
remove_duplicate_ut_entries.rb:25:in `split': invalid byte sequence in US-ASCII (ArgumentError)
	from remove_duplicate_ut_entries.rb:25:in `<main>'
--2024-05-18 18:54:54--  https://dumps.wikimedia.org/jawiki/latest/jawiki-latest-all-titles-in-ns0.gz
Resolving dumps.wikimedia.org (dumps.wikimedia.org)... 2620:0:861:3:208:80:154:71, 208.80.154.71
Connecting to dumps.wikimedia.org (dumps.wikimedia.org)|2620:0:861:3:208:80:154:71|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 14617435 (14M) [application/octet-stream]
Saving to: ‘jawiki-latest-all-titles-in-ns0.gz’

     0K .......... .......... .......... .......... ..........  0%  276K 52s

...

 14200K .......... .......... .......... .......... .......... 99% 34.9M 0s
 14250K .......... .......... ....                            100%  151M=7.3s

2024-05-18 18:55:02 (1.92 MB/s) - ‘jawiki-latest-all-titles-in-ns0.gz’ saved [14617435/14617435]

count_word_hits.rb:16:in `split': invalid byte sequence in US-ASCII (ArgumentError)
	from count_word_hits.rb:16:in `<main>'
apply_word_hits.rb:21:in `initialize': No such file or directory @ rb_sysopen - jawiki-latest-all-titles-in-ns0.hits (Errno::ENOENT)
	from apply_word_hits.rb:21:in `new'
	from apply_word_hits.rb:21:in `<main>'
```

### Cause
Similar error was mentioned in this article. https://qiita.com/shouta-dev/items/c8a03c98ad13842106e2

### Fix
This PR adds `encoding: "UTF-8"` option in all functions that open files.
```
Cloning into 'mozcdic-ut-jawiki'...
Cloning into 'mozcdic-ut-personal-names'...
Cloning into 'mozcdic-ut-place-names'...
Cloning into 'mozcdic-ut-sudachidict'...
--2024-05-18 18:57:31--  https://dumps.wikimedia.org/jawiki/latest/jawiki-latest-all-titles-in-ns0.gz
Resolving dumps.wikimedia.org (dumps.wikimedia.org)... 2620:0:861:3:208:80:154:71, 208.80.154.71
Connecting to dumps.wikimedia.org (dumps.wikimedia.org)|2620:0:861:3:208:80:154:71|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 14617435 (14M) [application/octet-stream]
Saving to: ‘jawiki-latest-all-titles-in-ns0.gz’

     0K .......... .......... .......... .......... ..........  0%  290K 49s

...

 14200K .......... .......... .......... .......... .......... 99% 11.8M 0s
 14250K .......... .......... ....                            100% 52.2M=11s

2024-05-18 18:57:43 (1.26 MB/s) - ‘jawiki-latest-all-titles-in-ns0.gz’ saved [14617435/14617435]
```