### PR TITLE
ci: Add build workflow which also provide files in user dictionary format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Mozc UT Dictionary
+
+on:
+  push:
+    branches: ["main"] # Or your default branch
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout workflow repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nkf wget bzip2 python3 perl coreutils
+
+      - name: Build the dictionary
+        run: |
+          cd src/merge
+          # enable all dicts
+          sed -i -r '/^#generate_latest=/! s/^#([^=]*="true")$/\1/' make.sh
+          sh make.sh
+        shell: bash
+
+      - name: Upload mozcdic-ut.txt artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mozcdic-ut
+          path: src/merge/mozcdic-ut.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           cd src/merge
           # enable all dicts
-          sed -i -r '/^#generate_latest=/! s/^#([^=]*="true")$/\1/' make.sh
+          sed -i -r '/^#generate_latest=/! s/^#([a-zA-Z0-9_]+="true")$/\1/' make.sh
+          echo "Configures: "
+          sed -n -r '/^#?[a-zA-Z0-9_]+=[^ ]*$/p' make.sh
           bash make.sh
         shell: bash
 
@@ -31,3 +33,11 @@ jobs:
         with:
           name: mozcdic-ut
           path: src/merge/mozcdic-ut.txt
+          if-no-files-found: error
+
+      - name: Upload mozcdic-ut.txt artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mozcdic-ut-user
+          path: src/merge/mozcdic-ut.user.*.txt
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           cd src/merge
           # enable all dicts
           sed -i -r '/^#generate_latest=/! s/^#([^=]*="true")$/\1/' make.sh
-          sh make.sh
+          bash make.sh
         shell: bash
 
       - name: Upload mozcdic-ut.txt artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nkf wget bzip2 python3 perl coreutils
+          sudo apt-get install -y wget bzip2 python3 coreutils
 
       - name: Build the dictionary
         run: |
@@ -28,14 +28,14 @@ jobs:
           bash make.sh
         shell: bash
 
-      - name: Upload mozcdic-ut.txt artifact
+      - name: Upload mozcdic-ut.txt to artifact
         uses: actions/upload-artifact@v4
         with:
           name: mozcdic-ut
           path: src/merge/mozcdic-ut.txt
           if-no-files-found: error
 
-      - name: Upload mozcdic-ut.txt artifact
+      - name: Upload user dictionary files to artifact
         uses: actions/upload-artifact@v4
         with:
           name: mozcdic-ut-user

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudachidict="true"
 
 ```
 cd src/merge/
-sh make.sh
+bash make.sh
 cat mozcdic-ut.txt >> ../../../mozc-master/src/data/dictionary_oss/dictionary00.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Uncomment ```#generate_latest="true"``` in src/merge/make.sh.
 
 It downloads the latest "jawiki-latest-pages-articles-multistream.xml.bz2" (4.1 GB).
 
+## Option: Generate user dictionary files
+
+Uncomment ```#generate_user_dictionaries="true"``` in src/merge/make.sh.
+
+This tool converts the generated dictionary into several files that you can import as a user dictionary directly, without rebuilding mozc. However, adding the dictionary at compile time generally yields better results, so prefer that approach if possible.
+
 ## Dictionaries
 
 Mozc UT dictionaries contain the following dictionaries:

--- a/src/merge/convert_to_user_dictionaries.py
+++ b/src/merge/convert_to_user_dictionaries.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Author: 7sDream (i at 7sdre dot am)
+# License: Apache License, Version 2.0
+
+import sys
+import csv
+import itertools
+
+
+def convert(line):
+    parts = line.strip().split("\t")
+    return [parts[0], parts[4], "名詞", ""]
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input-file> <output-base-name>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    out_base = sys.argv[2]
+
+    with open(input_file, "r", encoding="utf-8") as f:
+        data = map(convert, filter(lambda line: len(line.strip()) > 0, f))
+
+        # Mozc user dictionaries has 1000_000 max record limit.
+        volumes = []
+        for i, batch in enumerate(itertools.batched(data, 1000)):
+            i = i // 1000
+            if len(volumes) <= i:
+                o = open(
+                    f"{out_base}.{i + 1:>02}.txt", "w", encoding="utf-8", newline=""
+                )
+                writer = csv.writer(
+                    o,
+                    delimiter="\t",
+                    lineterminator="\n",
+                    quotechar='"',
+                    doublequote=False,
+                    escapechar="\\",
+                )
+                volumes.append([o, writer])
+            else:
+                o, writer = volumes[i]
+            writer.writerows(batch)
+
+        for o, _ in volumes:
+            o.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/merge/make.sh
+++ b/src/merge/make.sh
@@ -22,7 +22,7 @@ fi
 
 if [[ $alt_cannadic = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../alt-cannadic/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -32,7 +32,7 @@ fi
 
 if [[ $edict2 = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../edict2/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -42,7 +42,7 @@ fi
 
 if [[ $jawiki = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../jawiki/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -52,7 +52,7 @@ fi
 
 if [[ $neologd = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../neologd/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -66,7 +66,7 @@ fi
 
 if [[ $place_names = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../place-names/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -76,7 +76,7 @@ fi
 
 if [[ $skk_jisyo = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../skk-jisyo/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 
@@ -86,7 +86,7 @@ fi
 
 if [[ $sudachidict = "true" ]] && [[ $generate_latest = "true" ]]; then
     cd ../sudachidict/
-    sh make.sh
+    bash make.sh
     cd -
 fi
 

--- a/src/merge/make.sh
+++ b/src/merge/make.sh
@@ -12,6 +12,7 @@ place_names="true"
 #skk_jisyo="true"
 sudachidict="true"
 
+#generate_user_dictionaries="true"
 #generate_latest="true"
 
 rm -rf mozcdic-ut*
@@ -99,3 +100,7 @@ cat mozcdic-ut-*.txt > mozcdic-ut.txt
 
 # IDを更新、重複エントリを削除、コストを調整
 python merge_dictionaries.py mozcdic-ut.txt
+
+if [[ $generate_user_dictionaries = "true" ]]; then
+    python convert_to_user_dictionaries.py mozcdic-ut.txt mozcdic-ut.user
+fi


### PR DESCRIPTION
## Background

Since I use Windows, I cannot directly use the bash scripts in this repository for building. Therefore, I've added a GitHub Actions workflow to produce a usable dictionary file. Additionally, compiling mozc natively on Windows is somewhat complex, and my specific goal is to add this as a user dictionary, which led to the creation of a conversion script.

This work primarily stems from my personal needs, but I thought it might be beneficial to others as well, hence this pull request.

If you feel these changes don't align with the project's direction, please feel free to close this PR. I can continue using the artifacts generated by the CI in my own fork.

## About User Dictionary

The new `convert_to_user_dictionaries.py` script is added to handle the dictionary format conversion. Because mozc user dictionaries have a maximum limit of 1 million entries, the script also splits the dictionary into multiple volumes during the conversion process.

Testing confirms that these volumes can be successfully imported into mozc (using format auto-detect and UTF-8 encoding):

![dictimported](https://github.com/user-attachments/assets/b26a04bb-8bd3-46ee-b270-c79980c21259)

*Note: Each volume file contains exactly 1 million entries, however, a few dozen entries appear to be missing after import. The specific reason for this hasn't been investigated yet.*

The dictionary functions correctly after import:

![dicttest](https://github.com/user-attachments/assets/d4a544d8-1876-4737-b4f0-6f77c8aefccf)

BTW: I'm not deeply familiar with mozc's internal architecture. I expect that integrating the dictionary during compile time might yield better results than adding it as a user dictionary, but the user dictionary method fulfills my current requirements.

## Other Changes

In `make.sh`, changed `sh` to `bash` to align with the shebang(`#!/bin/bash`). This is because on some systems, `sh` points to `dash`, which doesn't support the Bash conditional syntax used in the script. See: https://superuser.com/questions/552016/bash-script-not-found

## CI Result Example

An example CI run can be viewed here: https://github.com/7sDream/merge-ut-dictionaries/actions/runs/14625018871